### PR TITLE
refactor: move scripts into backend package

### DIFF
--- a/backend/__init__.py
+++ b/backend/__init__.py
@@ -1,0 +1,25 @@
+"""Backend package for reusable workflow functions."""
+
+from .yolo import run_prediction, run_training
+from .collect_images import collect_images, setup_logger as setup_collect_logger
+from .convert_yolo_to_ls import convert_yolo_to_ls
+from .download_annotated import download_annotated
+from .generate_data_yaml import generate_data_yaml
+from .index_predictions_by_class import index_predictions
+from .stage_predictions_for_upload import stage_predictions
+from .train_yolo import run_training as run_full_training
+from .upload_gcs import upload as upload_gcs
+
+__all__ = [
+    "run_prediction",
+    "run_training",
+    "collect_images",
+    "setup_collect_logger",
+    "convert_yolo_to_ls",
+    "download_annotated",
+    "generate_data_yaml",
+    "index_predictions",
+    "stage_predictions",
+    "run_full_training",
+    "upload_gcs",
+]

--- a/backend/collect_images.py
+++ b/backend/collect_images.py
@@ -1,0 +1,117 @@
+import os
+import shutil
+import logging
+from pathlib import Path
+from datetime import datetime
+from filecmp import cmp
+from .utils import emit_status
+
+
+def ensure_dir(path):
+    os.makedirs(path, exist_ok=True)
+
+
+def setup_logger(log_dir: Path):
+    ensure_dir(log_dir)
+    now = datetime.now().strftime("%Y%m%d_%H%M%S")
+    log_path = log_dir / f"collect_{now}.log"
+    logging.basicConfig(
+        filename=log_path,
+        filemode='w',
+        format='[%(asctime)s] %(message)s',
+        level=logging.INFO,
+    )
+    return log_path
+
+
+def get_unique_name(dest_dir, original_name, source_prefix, method):
+    base = Path(original_name).stem
+    ext = Path(original_name).suffix.lower()
+
+    if method == "source_prefix":
+        return f"{source_prefix}_{base}{ext}"
+    elif method == "timestamp_hash":
+        now = datetime.now().strftime("%Y%m%d_%H%M%S_%f")
+        return f"{now}_{base}{ext}"
+    elif method == "sequential":
+        i = 0
+        new_name = f"{base}{ext}"
+        while (Path(dest_dir) / new_name).exists():
+            new_name = f"{base}_{i}{ext}"
+            i += 1
+        return new_name
+    else:
+        raise ValueError(f"Unknown rename_scheme: {method}")
+
+
+def collect_images(cfg):
+    sources = cfg["sources"]
+    dest_dir = Path(cfg["destination"])
+    rename_scheme = cfg.get("rename_scheme", "source_prefix")
+    rename_only_on_conflict = cfg.get("rename_only_on_conflict", False)
+    delete_missing = cfg.get("delete_missing_in_sources", False)
+    valid_exts = {ext.lower() for ext in cfg.get("extensions", [".jpg", ".jpeg", ".png"])}
+
+    ensure_dir(dest_dir)
+    seen_files = set()
+    total, copied, renamed, skipped = 0, 0, 0, 0
+    emit_status('start', action='collect_images', sources=len(sources))
+
+    for source in sources:
+        source_path = Path(source)
+        prefix = source_path.name
+        if not source_path.exists():
+            logging.warning(f"Source not found: {source_path}")
+            continue
+
+        for file in source_path.iterdir():
+            if file.suffix.lower() not in valid_exts or not file.is_file():
+                continue
+
+            base = file.stem
+            ext = file.suffix.lower()
+            dest_file = dest_dir / f"{base}{ext}"
+
+            if not dest_file.exists():
+                shutil.copy(file, dest_file)
+                seen_files.add(dest_file.name.lower())
+                logging.info(f"[ADD] {file} → {dest_file}")
+                copied += 1
+                emit_status('copied', file=str(file))
+            elif cmp(file, dest_file, shallow=False):
+                seen_files.add(dest_file.name.lower())
+                logging.info(f"[SKIP] Identical: {file.name}")
+                skipped += 1
+                emit_status('skipped', file=str(file))
+            else:
+                if rename_only_on_conflict:
+                    new_name = get_unique_name(dest_dir, file.name, prefix, rename_scheme)
+                    new_dest = dest_dir / new_name
+                    shutil.copy(file, new_dest)
+                    seen_files.add(new_dest.name.lower())
+                    logging.info(f"[RENAME] Conflict: {file.name} → {new_name}")
+                    renamed += 1
+                    emit_status('renamed', file=str(file), new_name=new_name)
+                else:
+                    shutil.copy(file, dest_file)
+                    seen_files.add(dest_file.name.lower())
+                    logging.info(f"[OVERWRITE] {file} → {dest_file}")
+                    copied += 1
+                    emit_status('overwritten', file=str(file))
+
+            total += 1
+
+    if delete_missing:
+        for existing_file in dest_dir.iterdir():
+            if existing_file.is_file() and existing_file.name.lower() not in seen_files:
+                existing_file.unlink()
+                logging.info(f"[DELETE] Removed missing source file: {existing_file.name}")
+                emit_status('deleted', file=str(existing_file))
+
+    emit_status('complete', action='collect_images', total=total, copied=copied, renamed=renamed, skipped=skipped)
+    return {
+        'total': total,
+        'copied': copied,
+        'renamed': renamed,
+        'skipped': skipped,
+    }

--- a/backend/convert_yolo_to_ls.py
+++ b/backend/convert_yolo_to_ls.py
@@ -1,0 +1,79 @@
+import json
+import logging
+from pathlib import Path
+from .utils import emit_status
+
+
+def load_classes(class_file):
+    with open(class_file, 'r') as f:
+        return [line.strip() for line in f.readlines() if line.strip()]
+
+
+def convert_yolo_to_ls(cfg):
+    label_dir = Path(cfg['labels_dir'])
+    image_dir = Path(cfg['image_dir'])
+    class_file = Path(cfg['classes_file'])
+    output_file = Path(cfg['output_file'])
+    image_prefix = cfg.get('image_prefix', 'gs://excessus-home-labelstudio/datasets1/')
+
+    emit_status('start', action='convert_yolo_to_ls', labels_dir=str(label_dir))
+
+    classes = load_classes(class_file)
+    label_files = sorted(label_dir.glob('*.txt'))
+    tasks = []
+
+    for label_file in label_files:
+        image_name = label_file.stem
+        image_path_jpg = image_dir / f"{image_name}.jpg"
+        image_path_JPG = image_dir / f"{image_name}.JPG"
+
+        if image_path_jpg.exists():
+            image_path = image_path_jpg
+        elif image_path_JPG.exists():
+            image_path = image_path_JPG
+        else:
+            logging.warning(f"Image not found for label: {label_file.name}")
+            continue
+
+        with open(label_file, 'r') as f:
+            lines = f.readlines()
+
+        results = []
+        for line in lines:
+            parts = line.strip().split()
+            if len(parts) != 5:
+                continue
+            cls_id, x, y, w, h = map(float, parts)
+            label = classes[int(cls_id)]
+            results.append({
+                "original_width": 9216,
+                "original_height": 5184,
+                "image_rotation": 0,
+                "value": {
+                    "x": (x - w / 2) * 100,
+                    "y": (y - h / 2) * 100,
+                    "width": w * 100,
+                    "height": h * 100,
+                    "rotation": 0,
+                    "rectanglelabels": [label],
+                },
+                "from_name": "label",
+                "to_name": "image",
+                "type": "rectanglelabels",
+                "origin": "manual",
+                "id": None,
+            })
+
+        task = {
+            "data": {"image": f"{image_prefix}{image_path.name}"},
+            "annotations": [{"result": results}],
+        }
+        tasks.append(task)
+        emit_status('converted', label=str(label_file), image=str(image_path))
+
+    output_file.parent.mkdir(parents=True, exist_ok=True)
+    with open(output_file, 'w') as f:
+        json.dump(tasks, f, indent=2)
+
+    emit_status('complete', action='convert_yolo_to_ls', tasks=len(tasks), output=str(output_file))
+    return tasks

--- a/backend/download_annotated.py
+++ b/backend/download_annotated.py
@@ -1,0 +1,66 @@
+import shutil
+import logging
+from pathlib import Path
+from .utils import emit_status
+
+
+def ensure_dir(path):
+    Path(path).mkdir(parents=True, exist_ok=True)
+
+
+def copy_matching_images(labels_dir, images_dir, output_dir):
+    labels_dir = Path(labels_dir)
+    images_dir = Path(images_dir)
+    output_images = Path(output_dir) / "images"
+    output_labels = Path(output_dir) / "labels"
+
+    ensure_dir(output_images)
+    ensure_dir(output_labels)
+
+    label_files = list(labels_dir.glob("*.txt"))
+    count = 0
+    missing = 0
+    renamed = 0
+
+    emit_status('start', action='download_annotated', labels=len(label_files))
+
+    for label_file in label_files:
+        original_stem = label_file.stem
+        base = original_stem.split("__", 1)[1] if "__" in original_stem else original_stem
+
+        candidates = list(images_dir.glob(f"{base}.*"))
+        img_file = next((c for c in candidates if c.suffix.lower() in ['.jpg', '.jpeg']), None)
+
+        if img_file and img_file.exists():
+            new_label_name = img_file.stem + ".txt"
+            new_label_path = output_labels / new_label_name
+
+            shutil.copy(img_file, output_images / img_file.name)
+            shutil.copy(label_file, new_label_path)
+
+            log_entry = f"[COPY] {img_file.name} and {new_label_name}"
+            if new_label_name != label_file.name:
+                renamed += 1
+                log_entry += f" (renamed from {label_file.name})"
+
+            logging.info(log_entry)
+            count += 1
+            emit_status('copied', image=str(img_file), label=new_label_name)
+        else:
+            logging.warning(f"[MISSING] No image found for label {label_file.name}")
+            missing += 1
+            emit_status('missing', label=str(label_file))
+
+    emit_status('complete', action='download_annotated', copied=count, renamed=renamed, missing=missing)
+    return {
+        'copied': count,
+        'renamed': renamed,
+        'missing': missing,
+    }
+
+
+def download_annotated(cfg):
+    labels_dir = cfg.get("labels_dir")
+    images_dir = cfg.get("images_dir")
+    output_dir = cfg.get("output_dir")
+    return copy_matching_images(labels_dir, images_dir, output_dir)

--- a/backend/generate_data_yaml.py
+++ b/backend/generate_data_yaml.py
@@ -1,0 +1,40 @@
+import json
+from pathlib import Path
+import yaml
+import logging
+from .utils import emit_status
+
+
+def ensure_dir(path):
+    Path(path).parent.mkdir(parents=True, exist_ok=True)
+
+
+def generate_data_yaml(cfg):
+    classes_path = Path(cfg["classes_file"])
+    output_path = Path(cfg["output_file"])
+    train_path = Path(cfg["train_images"])
+    val_path = Path(cfg["val_images"])
+
+    emit_status('start', action='generate_data_yaml')
+
+    if not classes_path.exists():
+        logging.error(f"Classes file not found: {classes_path}")
+        emit_status('error', message=f"Classes file not found: {classes_path}")
+        return
+
+    with open(classes_path, "r") as f:
+        classes = [line.strip() for line in f if line.strip()]
+
+    data = {
+        "train": str(train_path.resolve()),
+        "val": str(val_path.resolve()),
+        "nc": len(classes),
+        "names": classes,
+    }
+
+    ensure_dir(output_path)
+    with open(output_path, "w") as f:
+        yaml.dump(data, f, sort_keys=False)
+
+    emit_status('complete', action='generate_data_yaml', classes=len(classes), output=str(output_path))
+    return data

--- a/backend/index_predictions_by_class.py
+++ b/backend/index_predictions_by_class.py
@@ -1,0 +1,64 @@
+import os
+import json
+from glob import glob
+from .utils import emit_status
+
+
+def load_class_map(path):
+    with open(path, 'r') as f:
+        return {int(k): v for k, v in json.load(f).items()}
+
+
+def parse_txt_file(path):
+    class_ids = set()
+    with open(path, 'r') as f:
+        for line in f:
+            parts = line.strip().split()
+            if parts:
+                class_ids.add(int(parts[0]))
+    return list(class_ids)
+
+
+def index_predictions(cfg):
+    root_dir = cfg['source_dir']
+    output_path = cfg['output_json']
+    class_map_path = cfg['class_map']
+    filter_class = cfg.get('filter_class')
+
+    emit_status('start', action='index_predictions')
+
+    class_map = load_class_map(class_map_path)
+    reverse_class_map = {v: k for k, v in class_map.items()}
+    class_filter_id = reverse_class_map.get(filter_class) if filter_class else None
+
+    index = []
+
+    for labels_dir in glob(os.path.join(root_dir, 'predict*/labels')):
+        predict_dir = os.path.dirname(labels_dir)
+        video_file = next((f for f in os.listdir(predict_dir) if f.endswith('.avi')), None)
+        if not video_file:
+            continue
+
+        full_video_path = os.path.join(os.path.basename(predict_dir), video_file)
+
+        for txt_file in glob(os.path.join(labels_dir, '*.txt')):
+            class_ids = parse_txt_file(txt_file)
+            if not class_ids:
+                continue
+            if class_filter_id is not None and class_filter_id not in class_ids:
+                continue
+
+            entry = {
+                "video": full_video_path,
+                "frame_label": os.path.join(os.path.basename(predict_dir), 'labels', os.path.basename(txt_file)),
+                "class_ids": class_ids,
+                "class_names": [class_map[cid] for cid in class_ids if cid in class_map],
+            }
+            index.append(entry)
+            emit_status('indexed', file=os.path.basename(txt_file), classes=entry["class_names"])
+
+    with open(output_path, 'w') as f:
+        json.dump(index, f, indent=2)
+
+    emit_status('complete', action='index_predictions', entries=len(index), output=output_path)
+    return index

--- a/backend/stage_predictions_for_upload.py
+++ b/backend/stage_predictions_for_upload.py
@@ -1,0 +1,46 @@
+import shutil
+import logging
+from pathlib import Path
+from .utils import emit_status
+
+
+def load_config(path):
+    import json
+    with open(path, 'r') as f:
+        return json.load(f)
+
+
+def ensure_dir(path):
+    Path(path).mkdir(parents=True, exist_ok=True)
+
+
+def stage_predictions(cfg):
+    prediction_dir = Path(cfg['prediction_dir'])
+    labels_dir = prediction_dir / 'labels'
+    dest_root = Path(cfg['destination'])
+    images_dest = dest_root / 'images'
+    labels_dest = dest_root / 'labels'
+
+    ensure_dir(images_dest)
+    ensure_dir(labels_dest)
+
+    count = 0
+    skipped = 0
+    emit_status('start', action='stage_predictions')
+
+    for label_file in labels_dir.glob('*.txt'):
+        image_file = prediction_dir / label_file.name.replace('.txt', '.jpg')
+        if not image_file.exists():
+            logging.warning(f"Missing image for label: {label_file.name}")
+            skipped += 1
+            emit_status('missing_image', label=str(label_file))
+            continue
+
+        shutil.copy2(image_file, images_dest / image_file.name)
+        shutil.copy2(label_file, labels_dest / label_file.name)
+        logging.info(f"Staged: {image_file.name} and {label_file.name}")
+        emit_status('staged', image=image_file.name, label=label_file.name)
+        count += 1
+
+    emit_status('complete', action='stage_predictions', staged=count, skipped=skipped)
+    return {'staged': count, 'skipped': skipped}

--- a/backend/train_yolo.py
+++ b/backend/train_yolo.py
@@ -1,0 +1,53 @@
+import os
+import json
+from ultralytics import YOLO
+import yaml
+from .utils import emit_status
+
+
+def ensure_dir(path):
+    os.makedirs(path, exist_ok=True)
+
+
+def run_training(cfg):
+    model_path = cfg['model']
+    data = cfg['data']
+    output = cfg['output']
+    epochs = cfg.get('epochs', 100)
+    batch = cfg.get('batch', 16)
+    imgsz = cfg.get('imgsz', 640)
+
+    emit_status('start', action='train', model=model_path, data=data)
+
+    ensure_dir(output)
+    project = os.path.dirname(output)
+    name = os.path.basename(output)
+
+    model = YOLO(model_path)
+
+    with open(data, 'r') as f:
+        data_yaml = yaml.safe_load(f)
+
+    class_map = {str(i): name for i, name in enumerate(data_yaml['names'])}
+    source_classmap_path = os.path.join(os.path.dirname(data), "class_map.json")
+    with open(source_classmap_path, "w") as f:
+        json.dump(class_map, f, indent=2)
+    emit_status('class_map_saved', path=source_classmap_path)
+
+    class_map_final_path = os.path.join(output, "class_map.json")
+
+    model.train(
+        data=data,
+        epochs=epochs,
+        batch=batch,
+        imgsz=imgsz,
+        project=project,
+        name=name,
+        device=0,
+    )
+
+    with open(class_map_final_path, "w") as f:
+        json.dump(class_map, f, indent=2)
+    emit_status('class_map_copied', path=class_map_final_path)
+
+    emit_status('complete', action='train')

--- a/backend/upload_gcs.py
+++ b/backend/upload_gcs.py
@@ -1,0 +1,29 @@
+import subprocess
+import os
+from .utils import emit_status
+
+DRY_RUN = False
+DELETE_EXTRAS = False
+
+
+def build_rsync_command(local_path, gcs_path):
+    cmd = ['gsutil', '-m', 'rsync', '-r']
+    if DRY_RUN:
+        cmd.append('-n')
+    if DELETE_EXTRAS:
+        cmd.append('-d')
+    cmd.extend([local_path, gcs_path])
+    return cmd
+
+
+def upload(config):
+    local_path = os.path.expanduser(config['local_path'])
+    gcs_path = config['gcs_path']
+    emit_status('start', action='upload_gcs', source=local_path, destination=gcs_path)
+
+    cmd = build_rsync_command(local_path, gcs_path)
+    try:
+        subprocess.run(cmd, check=True)
+        emit_status('complete', action='upload_gcs')
+    except subprocess.CalledProcessError as e:
+        emit_status('error', action='upload_gcs', message=str(e))

--- a/backend/utils.py
+++ b/backend/utils.py
@@ -1,0 +1,10 @@
+import json
+import sys
+from typing import Any
+
+
+def emit_status(event: str, **data: Any) -> None:
+    """Emit a JSON status message to stdout."""
+    payload = {"event": event, **data}
+    print(json.dumps(payload))
+    sys.stdout.flush()

--- a/backend/yolo.py
+++ b/backend/yolo.py
@@ -1,0 +1,63 @@
+import os
+import subprocess
+from ultralytics import YOLO
+from .utils import emit_status
+
+
+def run_prediction(cfg):
+    model_path = cfg['model']
+    source = cfg['source']
+    output = cfg['output']
+    conf = cfg.get('conf', 0.25)
+
+    emit_status('start', action='predict', model=model_path, source=source)
+
+    os.makedirs(output, exist_ok=True)
+    project = os.path.dirname(output)
+    name = os.path.basename(output)
+
+    model = YOLO(model_path)
+    results = model.predict(
+        source=source,
+        save=True,
+        save_txt=True,
+        conf=conf,
+        project=project,
+        name=name,
+        device=0,
+        stream=True,
+    )
+
+    for r in results:
+        emit_status('prediction', file=getattr(r, 'path', ''), detections=len(getattr(r, 'boxes', [])))
+
+    if cfg.get('convert_to_ls'):
+        emit_status('conversion_start')
+        try:
+            from .convert_yolo_to_ls import convert_yolo_to_ls
+            convert_yolo_to_ls(cfg['convert_to_ls'])
+            emit_status('conversion_complete')
+        except Exception as e:
+            emit_status('conversion_error', error=str(e))
+
+    emit_status('complete', action='predict')
+
+
+def run_training(cfg):
+    model_path = cfg['model']
+    data_yaml = cfg['data']
+    output = cfg['output']
+    epochs = cfg.get('epochs', 100)
+    batch = cfg.get('batch', 16)
+    imgsz = cfg.get('imgsz', 640)
+
+    emit_status('start', action='train', model=model_path, data=data_yaml)
+
+    os.makedirs(output, exist_ok=True)
+    project = os.path.dirname(output)
+    name = os.path.basename(output)
+
+    model = YOLO(model_path)
+    model.train(data=data_yaml, epochs=epochs, batch=batch, imgsz=imgsz, project=project, name=name, save=True, plots=True)
+
+    emit_status('complete', action='train')

--- a/initial/scripts/collect_images.py
+++ b/initial/scripts/collect_images.py
@@ -3,106 +3,10 @@
 import os
 import sys
 import json
-import shutil
 import logging
 from pathlib import Path
-from datetime import datetime
-from filecmp import cmp
+from backend.collect_images import collect_images, setup_logger
 
-def ensure_dir(path):
-    os.makedirs(path, exist_ok=True)
-
-def setup_logger(log_dir: Path):
-    ensure_dir(log_dir)
-    now = datetime.now().strftime("%Y%m%d_%H%M%S")
-    log_path = log_dir / f"collect_{now}.log"
-    logging.basicConfig(
-        filename=log_path,
-        filemode='w',
-        format='[%(asctime)s] %(message)s',
-        level=logging.INFO
-    )
-    return log_path
-
-def get_unique_name(dest_dir, original_name, source_prefix, method):
-    base = Path(original_name).stem
-    ext = Path(original_name).suffix.lower()
-
-    if method == "source_prefix":
-        return f"{source_prefix}_{base}{ext}"
-    elif method == "timestamp_hash":
-        now = datetime.now().strftime("%Y%m%d_%H%M%S_%f")
-        return f"{now}_{base}{ext}"
-    elif method == "sequential":
-        i = 0
-        new_name = f"{base}{ext}"
-        while (Path(dest_dir) / new_name).exists():
-            new_name = f"{base}_{i}{ext}"
-            i += 1
-        return new_name
-    else:
-        raise ValueError(f"Unknown rename_scheme: {method}")
-
-def collect_images(cfg):
-    sources = cfg["sources"]
-    dest_dir = Path(cfg["destination"])
-    rename_scheme = cfg.get("rename_scheme", "source_prefix")
-    rename_only_on_conflict = cfg.get("rename_only_on_conflict", False)
-    delete_missing = cfg.get("delete_missing_in_sources", False)
-    valid_exts = set(ext.lower() for ext in cfg.get("extensions", [".jpg", ".jpeg", ".png"]))
-
-    ensure_dir(dest_dir)
-    seen_files = set()
-    total, copied, renamed, skipped = 0, 0, 0, 0
-
-    for source in sources:
-        source_path = Path(source)
-        prefix = source_path.name
-        if not source_path.exists():
-            logging.warning(f"Source not found: {source_path}")
-            continue
-
-        for file in source_path.iterdir():
-            if file.suffix.lower() not in valid_exts or not file.is_file():
-                continue
-
-            base = file.stem
-            ext = file.suffix.lower()
-            dest_file = dest_dir / f"{base}{ext}"
-
-            if not dest_file.exists():
-                shutil.copy(file, dest_file)
-                seen_files.add(dest_file.name.lower())
-                logging.info(f"[ADD] {file} → {dest_file}")
-                copied += 1
-            elif cmp(file, dest_file, shallow=False):
-                seen_files.add(dest_file.name.lower())
-                logging.info(f"[SKIP] Identical: {file.name}")
-                skipped += 1
-            else:
-                if rename_only_on_conflict:
-                    new_name = get_unique_name(dest_dir, file.name, prefix, rename_scheme)
-                    new_dest = dest_dir / new_name
-                    shutil.copy(file, new_dest)
-                    seen_files.add(new_dest.name.lower())
-                    logging.info(f"[RENAME] Conflict: {file.name} → {new_name}")
-                    renamed += 1
-                else:
-                    shutil.copy(file, dest_file)
-                    seen_files.add(dest_file.name.lower())
-                    logging.info(f"[OVERWRITE] {file} → {dest_file}")
-                    copied += 1
-
-            total += 1
-
-    if delete_missing:
-        for existing_file in dest_dir.iterdir():
-            if existing_file.is_file() and existing_file.name.lower() not in seen_files:
-                existing_file.unlink()
-                logging.info(f"[DELETE] Removed missing source file: {existing_file.name}")
-
-    print(f"\n[INFO] Processed {total} files from {len(sources)} sources.")
-    print(f"[INFO] Copied: {copied}, Renamed: {renamed}, Skipped: {skipped}")
 
 def main():
     if len(sys.argv) < 2:
@@ -131,6 +35,7 @@ def main():
 
     logging.info("=== Collection Complete ===")
     print(f"[INFO] Log written to {log_path}")
+
 
 if __name__ == "__main__":
     main()

--- a/initial/scripts/convert_yolo_to_ls.py
+++ b/initial/scripts/convert_yolo_to_ls.py
@@ -1,90 +1,11 @@
 # convert_yolo_to_ls.py
 
-import os
+import sys
 import json
-import logging
-from pathlib import Path
-from datetime import datetime
+from backend.convert_yolo_to_ls import convert_yolo_to_ls
 
-def load_classes(class_file):
-    with open(class_file, 'r') as f:
-        return [line.strip() for line in f.readlines() if line.strip()]
-
-def convert_yolo_to_ls(cfg):
-    label_dir = Path(cfg['labels_dir'])
-    image_dir = Path(cfg['image_dir'])
-    class_file = Path(cfg['classes_file'])
-    output_file = Path(cfg['output_file'])
-    image_prefix = cfg.get('image_prefix', 'gs://excessus-home-labelstudio/datasets1/')
-
-    classes = load_classes(class_file)
-    label_files = sorted([f for f in label_dir.glob('*.txt')])
-    tasks = []
-
-    for label_file in label_files:
-        image_name = label_file.stem
-        image_path_jpg = image_dir / f"{image_name}.jpg"
-        image_path_JPG = image_dir / f"{image_name}.JPG"
-
-        if image_path_jpg.exists():
-            image_path = image_path_jpg
-        elif image_path_JPG.exists():
-            image_path = image_path_JPG
-        else:
-            logging.warning(f"Image not found for label: {label_file.name}")
-            continue
-
-        with open(label_file, 'r') as f:
-            lines = f.readlines()
-
-        results = []
-        for line in lines:
-            parts = line.strip().split()
-            if len(parts) != 5:
-                continue
-            cls_id, x, y, w, h = map(float, parts)
-            label = classes[int(cls_id)]
-
-            results.append({
-                "original_width": 9216,
-                "original_height": 5184,
-                "image_rotation": 0,
-                "value": {
-                    "x": (x - w / 2) * 100,
-                    "y": (y - h / 2) * 100,
-                    "width": w * 100,
-                    "height": h * 100,
-                    "rotation": 0,
-                    "rectanglelabels": [label]
-                },
-                "from_name": "label",
-                "to_name": "image",
-                "type": "rectanglelabels",
-                "origin": "manual",
-                "id": None
-            })
-
-        task = {
-            "data": {
-                "image": f"{image_prefix}{image_path.name}"
-            },
-            "annotations": [
-                {
-                    "result": results
-                }
-            ]
-        }
-
-        tasks.append(task)
-
-    output_file.parent.mkdir(parents=True, exist_ok=True)
-    with open(output_file, 'w') as f:
-        json.dump(tasks, f, indent=2)
-
-    print(f"✅ Saved {len(tasks)} tasks to {output_file}")
 
 if __name__ == "__main__":
-    import sys
     if len(sys.argv) != 2:
         print("Usage: python convert_yolo_to_ls.py <config.json>")
         exit(1)

--- a/initial/scripts/generate_data_yaml.py
+++ b/initial/scripts/generate_data_yaml.py
@@ -3,12 +3,14 @@
 import sys
 import json
 from pathlib import Path
-import yaml
+from backend.generate_data_yaml import generate_data_yaml
 import logging
 from datetime import datetime
 
+
 def ensure_dir(path):
     Path(path).parent.mkdir(parents=True, exist_ok=True)
+
 
 def setup_logging(log_dir):
     Path(log_dir).mkdir(parents=True, exist_ok=True)
@@ -21,33 +23,6 @@ def setup_logging(log_dir):
         format='[%(levelname)s] %(message)s'
     )
     return log_path
-
-def generate_data_yaml(cfg):
-    classes_path = Path(cfg["classes_file"])
-    output_path = Path(cfg["output_file"])
-    train_path = Path(cfg["train_images"])
-    val_path = Path(cfg["val_images"])
-
-    if not classes_path.exists():
-        logging.error(f"Classes file not found: {classes_path}")
-        sys.exit(1)
-
-    with open(classes_path, "r") as f:
-        classes = [line.strip() for line in f if line.strip()]
-
-    data = {
-        "train": str(train_path.resolve()),
-        "val": str(val_path.resolve()),
-        "nc": len(classes),
-        "names": classes
-    }
-
-    ensure_dir(output_path)
-    with open(output_path, "w") as f:
-        yaml.dump(data, f, sort_keys=False)
-
-    logging.info(f"Wrote data.yaml with {len(classes)} classes to {output_path}")
-    print(f"[INFO] data.yaml created at: {output_path}")
 
 
 def main():
@@ -67,6 +42,7 @@ def main():
     print(f"[INFO] Log written to {log_path}\n")
 
     generate_data_yaml(cfg)
+
 
 if __name__ == "__main__":
     main()

--- a/initial/scripts/index_predictions_by_class.py
+++ b/initial/scripts/index_predictions_by_class.py
@@ -4,63 +4,7 @@ import os
 import sys
 import json
 import argparse
-from glob import glob
-
-
-def load_class_map(path):
-    with open(path, 'r') as f:
-        return {int(k): v for k, v in json.load(f).items()}
-
-
-def parse_txt_file(path):
-    class_ids = set()
-    with open(path, 'r') as f:
-        for line in f:
-            parts = line.strip().split()
-            if parts:
-                class_ids.add(int(parts[0]))
-    return list(class_ids)
-
-
-def build_index(config):
-    root_dir = config['source_dir']
-    output_path = config['output_json']
-    class_map_path = config['class_map']
-    filter_class = config.get('filter_class')
-
-    class_map = load_class_map(class_map_path)
-    reverse_class_map = {v: k for k, v in class_map.items()}
-    class_filter_id = reverse_class_map.get(filter_class) if filter_class else None
-
-    index = []
-
-    for labels_dir in glob(os.path.join(root_dir, 'predict*/labels')):
-        predict_dir = os.path.dirname(labels_dir)
-        video_file = next((f for f in os.listdir(predict_dir) if f.endswith('.avi')), None)
-        if not video_file:
-            continue
-
-        full_video_path = os.path.join(os.path.basename(predict_dir), video_file)
-
-        for txt_file in glob(os.path.join(labels_dir, '*.txt')):
-            class_ids = parse_txt_file(txt_file)
-            if not class_ids:
-                continue
-
-            if class_filter_id is not None and class_filter_id not in class_ids:
-                continue
-
-            entry = {
-                "video": full_video_path,
-                "frame_label": os.path.join(os.path.basename(predict_dir), 'labels', os.path.basename(txt_file)),
-                "class_ids": class_ids,
-                "class_names": [class_map[cid] for cid in class_ids if cid in class_map]
-            }
-            index.append(entry)
-
-    with open(output_path, 'w') as f:
-        json.dump(index, f, indent=2)
-    print(f"[INFO] Saved index with {len(index)} entries to {output_path}")
+from backend.index_predictions_by_class import index_predictions
 
 
 def main():
@@ -76,7 +20,7 @@ def main():
     with open(config_path, 'r') as f:
         cfg = json.load(f)
 
-    build_index(cfg)
+    index_predictions(cfg)
 
 
 if __name__ == "__main__":

--- a/initial/scripts/predict_yolo_image.py
+++ b/initial/scripts/predict_yolo_image.py
@@ -3,49 +3,7 @@
 import os
 import sys
 import json
-from ultralytics import YOLO
-import logging
-
-logging.basicConfig(
-    level=logging.INFO,
-    format='%(asctime)s [%(levelname)s] %(message)s',
-    handlers=[
-        logging.FileHandler("logs/predict_yolo_image.log"),
-        logging.StreamHandler(sys.stdout)
-    ]
-)
-
-
-def ensure_dir(path):
-    os.makedirs(path, exist_ok=True)
-
-def run_prediction(cfg):
-    model_path = cfg['model']
-    source = cfg['source']
-    output = cfg['output']
-    conf = cfg.get('conf', 0.25)
-
-    ensure_dir(output)
-
-    project = os.path.dirname(output)
-    name = os.path.basename(output)
-
-    print(f"[INFO] Starting prediction...\nModel: {model_path}\nSource: {source}\nOutput: {output}\nConf: {conf}\n")
-    model = YOLO(model_path)
-    results = model.predict(
-        source=source,
-        save=True,
-        save_txt=True,
-        conf=conf,
-        project=project,
-        name=name,
-        device=0,
-        stream=True
-
-    )
-
-    for r in results:
-        logging.info(f"Processed {r.path} with {len(r.boxes)} detections.")
+from backend.yolo import run_prediction
 
 
 def main():
@@ -62,6 +20,7 @@ def main():
         cfg = json.load(f)
 
     run_prediction(cfg)
+
 
 if __name__ == "__main__":
     main()

--- a/initial/scripts/predict_yolo_video.py
+++ b/initial/scripts/predict_yolo_video.py
@@ -1,59 +1,8 @@
-# scripts/predict_yolo_image.py
-
 import os
 import sys
 import json
-from ultralytics import YOLO
-import logging
-from glob import glob
+from backend.yolo import run_prediction
 
-logging.basicConfig(
-    level=logging.INFO,
-    format='%(asctime)s [%(levelname)s] %(message)s',
-    handlers=[
-        logging.FileHandler("logs/predict_yolo_video.log"),
-        logging.StreamHandler(sys.stdout)
-    ]
-)
-
-
-def ensure_dir(path):
-    os.makedirs(path, exist_ok=True)
-
-def run_prediction(cfg):
-    model_path = cfg['model']
-    source = cfg['source']
-    output = cfg['output']
-    conf = cfg.get('conf', 0.25)
-
-    ensure_dir(output)
-
-    project = os.path.dirname(output)
-    name = os.path.basename(output)
-
-    print(f"[INFO] Starting prediction...\nModel: {model_path}\nSource: {source}\nOutput: {output}\nConf: {conf}\n")
-    model = YOLO(model_path)
-
-    files = sorted(glob(os.path.join(source, "*.mp4")))  # or filter further if needed
-    total_files = len(files)
-
-    for idx, file in enumerate(files, start=1):
-        logging.info(f"[{idx}/{total_files}] Starting: {os.path.basename(file)}")
-
-        results = model.predict(
-            source=file,
-            save=True,
-            save_txt=True,
-            conf=conf,
-            project=project,
-            name=name,
-            device=0,
-            stream=True
-        )
-
-        for r in results:
-            n_boxes = len(r.boxes) if r.boxes else 0
-            logging.info(f"[{idx}/{total_files}] {os.path.basename(file)}: {n_boxes} detections in frame {r.path if hasattr(r, 'path') else '?'}")
 
 def main():
     if len(sys.argv) < 2:
@@ -69,6 +18,7 @@ def main():
         cfg = json.load(f)
 
     run_prediction(cfg)
+
 
 if __name__ == "__main__":
     main()

--- a/initial/scripts/run_yolo.py
+++ b/initial/scripts/run_yolo.py
@@ -1,58 +1,11 @@
 import argparse
 import json
-import os
-from ultralytics import YOLO
-from datetime import datetime
-import subprocess
+from backend.yolo import run_prediction, run_training
 
 
 def load_config(path):
     with open(path, 'r') as f:
         return json.load(f)
-
-
-def ensure_dir(path):
-    os.makedirs(path, exist_ok=True)
-
-
-def run_prediction(cfg):
-    model_path = cfg['model']
-    source = cfg['source']
-    output = cfg['output']
-    conf = cfg.get('conf', 0.25)
-
-    ensure_dir(output)
-
-    project = os.path.dirname(output)
-    name = os.path.basename(output)
-
-    model = YOLO(model_path)
-    model.predict(source=source, save=True, save_txt=True, conf=conf, project=project, name=name, device=0)
-
-    if cfg.get('convert_to_ls'):
-        converter_path = os.path.join(os.path.dirname(__file__), 'convert_yolo_to_ls.py')
-        if os.path.exists(converter_path):
-            print(f"\n[INFO] Running post-process conversion: {converter_path}\n")
-            subprocess.run(['python', converter_path, '--source', os.path.join(output, 'labels')])
-        else:
-            print("[WARN] convert_yolo_to_ls.py not found. Skipping conversion.")
-
-
-def run_training(cfg):
-    model_path = cfg['model']
-    data_yaml = cfg['data']
-    output = cfg['output']
-    epochs = cfg.get('epochs', 100)
-    batch = cfg.get('batch', 16)
-    imgsz = cfg.get('imgsz', 640)
-
-    ensure_dir(output)
-
-    project = os.path.dirname(output)
-    name = os.path.basename(output)
-
-    model = YOLO(model_path)
-    model.train(data=data_yaml, epochs=epochs, batch=batch, imgsz=imgsz, project=project, name=name, save=True, plots=True)
 
 
 def main():

--- a/initial/scripts/stage_predictions_for_upload.py
+++ b/initial/scripts/stage_predictions_for_upload.py
@@ -1,60 +1,25 @@
-import os
-import shutil
+import sys
 import json
 import logging
-from pathlib import Path
 from datetime import datetime
+from backend.stage_predictions_for_upload import stage_predictions
 
 logging.basicConfig(
     level=logging.INFO,
     format='[%(levelname)s] %(message)s',
     handlers=[
         logging.FileHandler(f"logs/image_merge/stage_{datetime.now().strftime('%Y%m%d_%H%M%S')}.log"),
-        logging.StreamHandler()
+        logging.StreamHandler(),
     ]
 )
 
-def load_config(path):
-    with open(path, 'r') as f:
-        return json.load(f)
-
-def ensure_dir(path):
-    Path(path).mkdir(parents=True, exist_ok=True)
-
-def stage_predictions(config_path):
-    config = load_config(config_path)
-
-    prediction_dir = Path(config['prediction_dir'])
-    labels_dir = prediction_dir / 'labels'
-    dest_root = Path(config['destination'])
-    images_dest = dest_root / 'images'
-    labels_dest = dest_root / 'labels'
-
-    ensure_dir(images_dest)
-    ensure_dir(labels_dest)
-
-    count = 0
-    skipped = 0
-
-    for label_file in labels_dir.glob('*.txt'):
-        image_file = prediction_dir / label_file.name.replace('.txt', '.jpg')
-
-        if not image_file.exists():
-            logging.warning(f"Missing image for label: {label_file.name}")
-            skipped += 1
-            continue
-
-        shutil.copy2(image_file, images_dest / image_file.name)
-        shutil.copy2(label_file, labels_dest / label_file.name)
-        logging.info(f"Staged: {image_file.name} and {label_file.name}")
-        count += 1
-
-    logging.info(f"[DONE] Staged {count} image/label pairs. Skipped: {skipped}")
 
 if __name__ == '__main__':
-    import sys
     if len(sys.argv) != 2:
         print("Usage: python stage_predictions_for_upload.py <config.json>")
         sys.exit(1)
 
-    stage_predictions(sys.argv[1])
+    config_path = sys.argv[1]
+    with open(config_path, 'r') as f:
+        cfg = json.load(f)
+    stage_predictions(cfg)

--- a/initial/scripts/train_yolo.py
+++ b/initial/scripts/train_yolo.py
@@ -1,64 +1,7 @@
-# scripts/train_yolo.py
-
 import os
 import sys
 import json
-from ultralytics import YOLO
-import yaml
-
-def ensure_dir(path):
-    os.makedirs(path, exist_ok=True)
-
-def run_training(cfg):
-    model_path = cfg['model']
-    data = cfg['data']
-    output = cfg['output']
-    epochs = cfg.get('epochs', 100)
-    batch = cfg.get('batch', 16)
-    imgsz = cfg.get('imgsz', 640)
-
-    ensure_dir(output)
-
-    project = os.path.dirname(output)
-    name = os.path.basename(output)
-
-    print(f"[INFO] Starting training...\nModel: {model_path}\nData: {data}\nOutput: {output}\nEpochs: {epochs}\nBatch: {batch}\nImg Size: {imgsz}\n")
-
-    model = YOLO(model_path)
-
-#####Create Class Mappings
-    # Load and save class map from data.yaml
-    with open(data, 'r') as f:
-        data_yaml = yaml.safe_load(f)
-
-    class_map = {str(i): name for i, name in enumerate(data_yaml['names'])}
-
-    # Save to source (next to model config)
-    source_classmap_path = os.path.join(os.path.dirname(data), "class_map.json")
-    with open(source_classmap_path, "w") as f:
-        json.dump(class_map, f, indent=2)
-
-    # Temp: hold until success
-    class_map_final_path = os.path.join(output, "class_map.json")
-    print(f"[INFO] Saved class map: {source_classmap_path}")
-
-###############
-
-
-    model.train(
-        data=data,
-        epochs=epochs,
-        batch=batch,
-        imgsz=imgsz,
-        project=project,
-        name=name,
-        device=0
-    )
-
-    # Save again in final output
-    with open(class_map_final_path, "w") as f:
-        json.dump(class_map, f, indent=2)
-    print(f"[INFO] Class map copied to output: {class_map_final_path}")
+from backend.train_yolo import run_training
 
 
 def main():
@@ -75,6 +18,7 @@ def main():
         cfg = json.load(f)
 
     run_training(cfg)
+
 
 if __name__ == "__main__":
     main()

--- a/initial/scripts/upload_gcs.py
+++ b/initial/scripts/upload_gcs.py
@@ -1,45 +1,14 @@
 #!/usr/bin/env python3
 
-import subprocess
-import os
 import json
 import sys
+from backend.upload_gcs import upload
 
-# Flags
-DRY_RUN = False  # Set to True to preview without uploading
-DELETE_EXTRAS = False  # Set to True if you want to mirror (deletes remote files not in local)
 
 def load_config(config_path):
     with open(config_path, 'r') as f:
         return json.load(f)
 
-def build_rsync_command(local_path, gcs_path):
-    cmd = ['gsutil', '-m', 'rsync', '-r']
-
-    if DRY_RUN:
-        cmd.append('-n')
-
-    if DELETE_EXTRAS:
-        cmd.append('-d')  # Dangerous! Removes files in GCS not present locally
-
-    cmd.extend([local_path, gcs_path])
-    return cmd
-
-def upload(config):
-    local_path = os.path.expanduser(config['local_path'])
-    gcs_path = config['gcs_path']
-
-    print(f"Uploading from:\n  {local_path}\nto:\n  {gcs_path}\n")
-
-    if DRY_RUN:
-        print("⚠️  DRY RUN ENABLED – no changes will be made.\n")
-
-    cmd = build_rsync_command(local_path, gcs_path)
-    try:
-        subprocess.run(cmd, check=True)
-        print("\n✅ Upload completed.")
-    except subprocess.CalledProcessError as e:
-        print(f"\n❌ Upload failed with error: {e}")
 
 if __name__ == "__main__":
     if len(sys.argv) != 2:


### PR DESCRIPTION
## Summary
- create `backend` package with reusable workflow functions
- emit structured JSON status updates for training, prediction and utilities
- simplify original scripts to CLI wrappers calling backend functions

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_688f33b136e883319e465439b231b26d