### PR TITLE
feat: connect training page to backend

### DIFF
--- a/site/app/api/status/route.ts
+++ b/site/app/api/status/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from "next/server"
 import { spawn } from "child_process"
 import path from "path"
 import fs from "fs/promises"
+import { WorkflowDatabase } from "@/lib/database"
 
 export async function GET() {
   try {
@@ -71,8 +72,19 @@ async function getStorageStatus() {
 }
 
 async function getActiveProcesses() {
-  // Check for active training/prediction processes
-  return []
+  try {
+    const sessions = WorkflowDatabase.getTrainingSessions()
+      .sort((a, b) => (b.id || 0) - (a.id || 0))
+    return sessions.map((s) => ({
+      id: s.id,
+      type: "train",
+      status: s.status,
+      progress: s.progress,
+      metrics: s.metrics,
+    }))
+  } catch {
+    return []
+  }
 }
 
 async function getRecentLogs() {


### PR DESCRIPTION
## Summary
- trigger backend training script and poll progress from `/api/status`
- expose training session progress from the WorkflowDatabase via `/api/status`

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: requires interactive ESLint config)


------
https://chatgpt.com/codex/tasks/task_e_688f38c99dac8331990845add7d5468c