### PR TITLE
Use environment variables for paths

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,3 @@
+DATA_DIR=./data
+SCRIPTS_DIR=./initial/scripts
+DB_PATH=./data/workflow.db

--- a/README.md
+++ b/README.md
@@ -6,6 +6,19 @@ The push it towards the newly created website, but simple CLI support should rem
 
 The app is mainly a collection of scripts that fetch files, organize files, transform as desired, stage for training, run training, run predictions, view media, and evenually bypass the need for LabelStudio basic annotation. 
 
-Integration with cloud services is supported for annotation, along side full local as developed.  -- Label Studio is heavily geared for Cloud annotation flow, which may not be preferrable by some. 
+Integration with cloud services is supported for annotation, along side full local as developed.  -- Label Studio is heavily geared for Cloud annotation flow, which may not be preferrable by some.
+
+
+## Environment Variables
+
+Configuration relies on a few environment variables which can be set in a `.env` file at the project root.
+
+| Variable      | Description                               | Default               |
+|---------------|-------------------------------------------|-----------------------|
+| `DATA_DIR`    | Base directory for datasets and logs       | `./data`              |
+| `SCRIPTS_DIR` | Location of Python utility scripts         | `./initial/scripts`   |
+| `DB_PATH`     | Path to the workflow SQLite database file  | `./data/workflow.db`  |
+
+When these variables are not provided, the application will fall back to the defaults above which are relative to the repository root.
 
 

--- a/initial/scripts/collect_images.py
+++ b/initial/scripts/collect_images.py
@@ -21,7 +21,8 @@ def main():
     with open(config_path, "r") as f:
         cfg = json.load(f)
 
-    log_dir = Path("logs/image_merge")
+    data_dir = Path(os.getenv("DATA_DIR", "."))
+    log_dir = data_dir / "logs" / "image_merge"
     log_path = setup_logger(log_dir)
 
     logging.info("=== Starting Image Collection ===")

--- a/initial/scripts/download_annotated.py
+++ b/initial/scripts/download_annotated.py
@@ -1,7 +1,6 @@
 # scripts/download_annotated.py
 
 import os
-import os
 import sys
 import json
 import logging
@@ -48,7 +47,8 @@ def main():
         print("[ERROR] Config must include 'labels_dir', 'images_dir', and 'output_dir'.")
         sys.exit(1)
 
-    log_path = setup_logging("logs/download")
+    data_dir = Path(os.getenv("DATA_DIR", "."))
+    log_path = setup_logging(data_dir / "logs" / "download")
     print(f"[INFO] Log written to {log_path}\n")
     download_annotated(cfg)
 

--- a/initial/scripts/generate_data_yaml.py
+++ b/initial/scripts/generate_data_yaml.py
@@ -1,5 +1,6 @@
 # scripts/generate_data_yaml.py
 
+import os
 import sys
 import json
 from pathlib import Path
@@ -38,7 +39,8 @@ def main():
     with open(config_path, "r") as f:
         cfg = json.load(f)
 
-    log_path = setup_logging("logs/data_yaml")
+    data_dir = Path(os.getenv("DATA_DIR", "."))
+    log_path = setup_logging(data_dir / "logs" / "data_yaml")
     print(f"[INFO] Log written to {log_path}\n")
 
     generate_data_yaml(cfg)

--- a/initial/scripts/stage_predictions_for_upload.py
+++ b/initial/scripts/stage_predictions_for_upload.py
@@ -1,14 +1,17 @@
 import sys
 import json
 import logging
+import os
+from pathlib import Path
 from datetime import datetime
 from backend.stage_predictions_for_upload import stage_predictions
 
+logs_dir = Path(os.getenv("DATA_DIR", ".")) / "logs" / "image_merge"
 logging.basicConfig(
     level=logging.INFO,
     format='[%(levelname)s] %(message)s',
     handlers=[
-        logging.FileHandler(f"logs/image_merge/stage_{datetime.now().strftime('%Y%m%d_%H%M%S')}.log"),
+        logging.FileHandler(logs_dir / f"stage_{datetime.now().strftime('%Y%m%d_%H%M%S')}.log"),
         logging.StreamHandler(),
     ]
 )

--- a/site/app/api/scripts/route.ts
+++ b/site/app/api/scripts/route.ts
@@ -22,12 +22,14 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ error: "Invalid script name" }, { status: 400 })
     }
 
-    const scriptPath = path.join(process.cwd(), "scripts", script)
+    const scriptsDir = process.env.SCRIPTS_DIR || path.join(process.cwd(), "..", "initial", "scripts")
+    const scriptPath = path.join(scriptsDir, script)
 
     // Create temporary config file if config is provided
     let configPath = null
     if (config) {
-      const configDir = path.join(process.cwd(), "temp", "configs")
+      const dataDir = process.env.DATA_DIR || path.join(process.cwd(), "..", "data")
+      const configDir = path.join(dataDir, "temp", "configs")
       await fs.mkdir(configDir, { recursive: true })
       configPath = path.join(configDir, `config_${Date.now()}.json`)
       await fs.writeFile(configPath, JSON.stringify(config, null, 2))

--- a/site/app/api/status/route.ts
+++ b/site/app/api/status/route.ts
@@ -61,7 +61,8 @@ async function getGPUStatus() {
 
 async function getStorageStatus() {
   try {
-    const stats = await fs.stat(process.cwd())
+    const dataDir = process.env.DATA_DIR || path.join(process.cwd(), "..", "data")
+    const stats = await fs.stat(dataDir)
     return {
       available: true,
       // Add more storage metrics as needed
@@ -89,7 +90,8 @@ async function getActiveProcesses() {
 
 async function getRecentLogs() {
   try {
-    const logsDir = path.join(process.cwd(), "logs", "api")
+    const dataDir = process.env.DATA_DIR || path.join(process.cwd(), "..", "data")
+    const logsDir = path.join(dataDir, "logs", "api")
     const files = await fs.readdir(logsDir)
     const recentFile = files.sort().pop()
 

--- a/site/lib/database.ts
+++ b/site/lib/database.ts
@@ -1,7 +1,8 @@
 import Database from "better-sqlite3"
 import path from "path"
 
-const dbPath = path.join(process.cwd(), "data", "workflow.db")
+const dataDir = process.env.DATA_DIR || path.join(process.cwd(), "data")
+const dbPath = process.env.DB_PATH || path.join(dataDir, "workflow.db")
 const db = new Database(dbPath)
 
 // Initialize database schema


### PR DESCRIPTION
## Summary
- centralize data, script, and database locations via `.env`
- make Python utilities and Next.js API routes read paths from environment variables
- document configuration variables and defaults in README

## Testing
- `python -m py_compile initial/scripts/collect_images.py initial/scripts/download_annotated.py initial/scripts/generate_data_yaml.py initial/scripts/stage_predictions_for_upload.py`
- `pnpm lint` *(fails: How would you like to configure ESLint?)*

------
https://chatgpt.com/codex/tasks/task_e_688f3b0128c88331afc6f45260a50ca3