### PR TITLE
feat: stream script output to client

### DIFF
--- a/site/app/api/scripts/route.ts
+++ b/site/app/api/scripts/route.ts
@@ -3,21 +3,13 @@ import { spawn } from "child_process"
 import path from "path"
 import fs from "fs/promises"
 import { WorkflowDatabase } from "@/lib/database"
+import { allowedScripts } from "@/config/scripts"
 
 export async function POST(request: NextRequest) {
   try {
     const { script, config, action } = await request.json()
 
     // Validate script name to prevent path traversal
-    const allowedScripts = [
-      "run_yolo.py",
-      "collect_images.py",
-      "convert_yolo_to_ls.py",
-      "download_annotated.py",
-      "generate_data_yaml.py",
-      "index_predictions_by_class.py",
-    ]
-
     if (!allowedScripts.includes(script)) {
       return NextResponse.json({ error: "Invalid script name" }, { status: 400 })
     }
@@ -26,7 +18,7 @@ export async function POST(request: NextRequest) {
     const scriptPath = path.join(scriptsDir, script)
 
     // Create temporary config file if config is provided
-    let configPath = null
+    let configPath: string | null = null
     if (config) {
       const dataDir = process.env.DATA_DIR || path.join(process.cwd(), "..", "data")
       const configDir = path.join(dataDir, "temp", "configs")
@@ -38,99 +30,129 @@ export async function POST(request: NextRequest) {
     // Prepare command arguments
     const args = configPath ? [scriptPath, configPath] : [scriptPath]
 
-    return new Promise((resolve) => {
-      const process = spawn("python3", args)
-      let stdout = ""
-      let stderr = ""
-      let buffer = ""
-
-      // Insert initial database row based on action
-      let recordId: number | null = null
-      if (action === "train") {
-        recordId = WorkflowDatabase.createTrainingSession({
-          project_id: config?.project_id,
-          model_name: config?.model,
-          dataset_path: config?.data,
-          epochs: config?.epochs,
-          batch_size: config?.batch,
-          status: "running",
-        })
-      } else if (action === "predict") {
-        recordId = WorkflowDatabase.createPrediction({
-          project_id: config?.project_id,
-          model_name: config?.model,
-          source_path: config?.source,
-          output_path: config?.output,
-          confidence_threshold: config?.conf,
-          status: "running",
-        })
+    let child
+    try {
+      child = spawn("python3", args)
+    } catch (error) {
+      console.error("Failed to spawn script:", error)
+      if (configPath) {
+        try {
+          await fs.unlink(configPath)
+        } catch {}
       }
+      WorkflowDatabase.logActivity({
+        action: "script_error",
+        details: JSON.stringify({ error: String(error) }),
+        status: "error",
+      })
+      return NextResponse.json(
+        { error: "Failed to start script", details: String(error) },
+        { status: 500 },
+      )
+    }
 
-      process.stdout.on("data", (data) => {
-        const text = data.toString()
-        stdout += text
-        buffer += text
+    const encoder = new TextEncoder()
+    let buffer = ""
 
-        const lines = buffer.split(/\r?\n/)
-        buffer = lines.pop() || ""
+    // Insert initial database row based on action
+    let recordId: number | null = null
+    if (action === "train") {
+      recordId = WorkflowDatabase.createTrainingSession({
+        project_id: config?.project_id,
+        model_name: config?.model,
+        dataset_path: config?.data,
+        epochs: config?.epochs,
+        batch_size: config?.batch,
+        status: "running",
+      })
+    } else if (action === "predict") {
+      recordId = WorkflowDatabase.createPrediction({
+        project_id: config?.project_id,
+        model_name: config?.model,
+        source_path: config?.source,
+        output_path: config?.output,
+        confidence_threshold: config?.conf,
+        status: "running",
+      })
+    }
 
-        for (const line of lines) {
-          if (action === "train" && recordId !== null) {
-            const match = line.match(/Epoch\s+(\d+)\/(\d+)/i)
-            if (match) {
-              const current = Number(match[1])
-              const total = Number(match[2])
-              const progress = (current / total) * 100
-              WorkflowDatabase.updateTrainingSession(recordId, {
-                progress,
-                metrics: line.trim(),
-              })
+    const stream = new ReadableStream<Uint8Array>({
+      start(controller) {
+        const send = (type: string, data: any) => {
+          controller.enqueue(
+            encoder.encode(`data: ${JSON.stringify({ type, data })}\n\n`),
+          )
+        }
+
+        child.stdout.on("data", (chunk) => {
+          const text = chunk.toString()
+          send("stdout", text)
+          buffer += text
+
+          const lines = buffer.split(/\r?\n/)
+          buffer = lines.pop() || ""
+
+          for (const line of lines) {
+            if (action === "train" && recordId !== null) {
+              const match = line.match(/Epoch\s+(\d+)\/(\d+)/i)
+              if (match) {
+                const current = Number(match[1])
+                const total = Number(match[2])
+                const progress = (current / total) * 100
+                WorkflowDatabase.updateTrainingSession(recordId, {
+                  progress,
+                  metrics: line.trim(),
+                })
+              }
             }
           }
-        }
-      })
-
-      process.stderr.on("data", (data) => {
-        stderr += data.toString()
-      })
-
-      process.on("close", async (code) => {
-        // Clean up temporary config file
-        if (configPath) {
-          try {
-            await fs.unlink(configPath)
-          } catch (error) {
-            console.error("Failed to clean up config file:", error)
-          }
-        }
-
-        if (action === "train" && recordId !== null) {
-          WorkflowDatabase.updateTrainingSession(recordId, {
-            status: code === 0 ? "completed" : "failed",
-            progress: 100,
-            completed_at: new Date().toISOString(),
-          })
-        } else if (action === "predict" && recordId !== null) {
-          WorkflowDatabase.updatePrediction(recordId, {
-            status: code === 0 ? "completed" : "failed",
-          })
-        }
-
-        WorkflowDatabase.logActivity({
-          action,
-          details: JSON.stringify({ script, config }),
-          status: code === 0 ? "success" : "error",
         })
 
-        resolve(
-          NextResponse.json({
-            success: code === 0,
-            exitCode: code,
-            stdout,
-            stderr,
-          }),
-        )
-      })
+        child.stderr.on("data", (chunk) => {
+          send("stderr", chunk.toString())
+        })
+
+        child.on("close", async (code) => {
+          if (configPath) {
+            try {
+              await fs.unlink(configPath)
+            } catch (error) {
+              console.error("Failed to clean up config file:", error)
+            }
+          }
+
+          if (action === "train" && recordId !== null) {
+            WorkflowDatabase.updateTrainingSession(recordId, {
+              status: code === 0 ? "completed" : "failed",
+              progress: 100,
+              completed_at: new Date().toISOString(),
+            })
+          } else if (action === "predict" && recordId !== null) {
+            WorkflowDatabase.updatePrediction(recordId, {
+              status: code === 0 ? "completed" : "failed",
+            })
+          }
+
+          WorkflowDatabase.logActivity({
+            action,
+            details: JSON.stringify({ script, config }),
+            status: code === 0 ? "success" : "error",
+          })
+
+          send("close", { code })
+          controller.close()
+        })
+
+        child.on("error", (err) => {
+          console.error("Process error:", err)
+          send("error", String(err))
+          controller.close()
+        })
+      },
+    })
+
+    return new NextResponse(stream, {
+      headers: { "Content-Type": "text/event-stream" },
     })
   } catch (error) {
     console.error("Script execution error:", error)
@@ -139,6 +161,9 @@ export async function POST(request: NextRequest) {
       details: JSON.stringify({ error: String(error) }),
       status: "error",
     })
-    return NextResponse.json({ error: "Script execution failed" }, { status: 500 })
+    return NextResponse.json(
+      { error: "Script execution failed", details: String(error) },
+      { status: 500 },
+    )
   }
 }

--- a/site/config/scripts.ts
+++ b/site/config/scripts.ts
@@ -1,0 +1,8 @@
+export const allowedScripts = [
+  "run_yolo.py",
+  "collect_images.py",
+  "convert_yolo_to_ls.py",
+  "download_annotated.py",
+  "generate_data_yaml.py",
+  "index_predictions_by_class.py",
+];


### PR DESCRIPTION
## Summary
- move list of allowed scripts to shared config module
- stream Python stdout/stderr over API using `ReadableStream`
- guard `spawn` with try/catch and return structured errors

## Testing
- `npm run lint` *(fails: prompts for ESLint configuration)*
- `npm run build` *(fails: Could not locate better-sqlite3 bindings)*

------
https://chatgpt.com/codex/tasks/task_e_688f3e1bca2483318ff1e263af7dd540