### PR TITLE
feat: log job progress to database

### DIFF
--- a/backend/utils.py
+++ b/backend/utils.py
@@ -1,10 +1,20 @@
 import json
 import sys
-from typing import Any
+from typing import Any, Callable, Optional
+
+_status_callback: Optional[Callable[[str, dict], None]] = None
+
+
+def set_status_callback(cb: Optional[Callable[[str, dict], None]]) -> None:
+    """Register a callback invoked whenever :func:`emit_status` is called."""
+    global _status_callback
+    _status_callback = cb
 
 
 def emit_status(event: str, **data: Any) -> None:
-    """Emit a JSON status message to stdout."""
+    """Emit a JSON status message to stdout and invoke the status callback."""
     payload = {"event": event, **data}
     print(json.dumps(payload))
     sys.stdout.flush()
+    if _status_callback is not None:
+        _status_callback(event, data)


### PR DESCRIPTION
## Summary
- allow backend jobs to report progress via optional database callbacks
- track prediction and training runs in the database
- record collect-images job details and completion metrics

## Testing
- `npm test --prefix site` *(fails: Missing script "test")*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688f46a41968833186bb481358321ffd