### PR TITLE
Load environment variables via python-dotenv

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Integration with cloud services is supported for annotation, along side full loc
 ## Environment Variables
 
 Configuration relies on a few environment variables which can be set in a `.env` file at the project root.
+The backend loads this file automatically using [`python-dotenv`](https://pypi.org/project/python-dotenv/).
 
 | Variable      | Description                               | Default               |
 |---------------|-------------------------------------------|-----------------------|

--- a/backend/__init__.py
+++ b/backend/__init__.py
@@ -1,5 +1,10 @@
 """Backend package for reusable workflow functions."""
 
+from dotenv import load_dotenv
+
+# Load environment variables from a .env file before importing other modules.
+load_dotenv()
+
 from .yolo import run_prediction, run_training
 from .collect_images import collect_images, setup_logger as setup_collect_logger
 from .convert_yolo_to_ls import convert_yolo_to_ls


### PR DESCRIPTION
## Summary
- load environment variables from `.env` using `python-dotenv`
- document automatic `.env` loading in README

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_688f4e8019e48331ad70af19d470865f