### PR TITLE
Add shared ensure_dir utility

### DIFF
--- a/backend/collect_images.py
+++ b/backend/collect_images.py
@@ -6,11 +6,7 @@ import logging
 from pathlib import Path
 from datetime import datetime
 from filecmp import cmp
-from .utils import emit_status, set_status_callback
-
-
-def ensure_dir(path):
-    os.makedirs(path, exist_ok=True)
+from .utils import emit_status, set_status_callback, ensure_dir
 
 
 def setup_logger(log_dir: Path):

--- a/backend/generate_data_yaml.py
+++ b/backend/generate_data_yaml.py
@@ -1,16 +1,11 @@
 import json
 import os
 import sys
-import json
 from pathlib import Path
 import yaml
 import logging
 from datetime import datetime
-from .utils import emit_status
-
-
-def ensure_dir(path):
-    Path(path).parent.mkdir(parents=True, exist_ok=True)
+from .utils import emit_status, ensure_dir
 
 
 def generate_data_yaml(cfg):
@@ -36,7 +31,7 @@ def generate_data_yaml(cfg):
         "names": classes,
     }
 
-    ensure_dir(output_path)
+    ensure_dir(output_path.parent)
     with open(output_path, "w") as f:
         yaml.dump(data, f, sort_keys=False)
 

--- a/backend/train_yolo.py
+++ b/backend/train_yolo.py
@@ -2,11 +2,7 @@ import os
 import json
 from ultralytics import YOLO
 import yaml
-from .utils import emit_status
-
-
-def ensure_dir(path):
-    os.makedirs(path, exist_ok=True)
+from .utils import emit_status, ensure_dir
 
 
 def run_training(cfg):

--- a/backend/utils.py
+++ b/backend/utils.py
@@ -1,8 +1,14 @@
 import json
 import sys
+from pathlib import Path
 from typing import Any, Callable, Optional
 
 _status_callback: Optional[Callable[[str, dict], None]] = None
+
+
+def ensure_dir(path: str | Path) -> None:
+    """Create a directory and its parents if they do not exist."""
+    Path(path).mkdir(parents=True, exist_ok=True)
 
 
 def set_status_callback(cb: Optional[Callable[[str, dict], None]]) -> None:


### PR DESCRIPTION
## Summary
- centralize ensure_dir helper in `backend.utils`
- reuse new helper in collection, data YAML generation, and YOLO training modules

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688f5013b8d88331b5f8f39dbfe85158