### PR TITLE
Add dry-run and delete options to GCS upload

### DIFF
--- a/backend/upload_gcs.py
+++ b/backend/upload_gcs.py
@@ -4,26 +4,52 @@ import sys
 import json
 from .utils import emit_status
 
-DRY_RUN = False
-DELETE_EXTRAS = False
 
+def build_rsync_command(local_path, gcs_path, *, dry_run: bool = False, delete_extras: bool = False):
+    """Build the ``gsutil rsync`` command.
 
-def build_rsync_command(local_path, gcs_path):
-    cmd = ['gsutil', '-m', 'rsync', '-r']
-    if DRY_RUN:
-        cmd.append('-n')
-    if DELETE_EXTRAS:
-        cmd.append('-d')
+    Args:
+        local_path: Source directory on the local filesystem.
+        gcs_path: Destination path in Google Cloud Storage.
+        dry_run: If ``True``, include ``-n`` to perform a trial run with no
+            changes made.
+        delete_extras: If ``True``, include ``-d`` so that files present in the
+            destination but not in the source are deleted.
+
+    Returns:
+        List[str]: The full command ready to be passed to ``subprocess``.
+    """
+
+    cmd = ["gsutil", "-m", "rsync", "-r"]
+    if dry_run:
+        cmd.append("-n")
+    if delete_extras:
+        cmd.append("-d")
     cmd.extend([local_path, gcs_path])
     return cmd
 
 
-def upload(config):
-    local_path = os.path.expanduser(config['local_path'])
-    gcs_path = config['gcs_path']
-    emit_status('start', action='upload_gcs', source=local_path, destination=gcs_path)
+def _env_bool(name: str, default: bool = False) -> bool:
+    """Return environment variable ``name`` interpreted as a boolean."""
 
-    cmd = build_rsync_command(local_path, gcs_path)
+    value = os.getenv(name)
+    if value is None:
+        return default
+    return value.lower() in {"1", "true", "yes", "on"}
+
+
+def upload(config):
+    local_path = os.path.expanduser(config["local_path"])
+    gcs_path = config["gcs_path"]
+    dry_run = config.get("dry_run", _env_bool("UPLOAD_GCS_DRY_RUN"))
+    delete_extras = config.get(
+        "delete_extras", _env_bool("UPLOAD_GCS_DELETE_EXTRAS")
+    )
+    emit_status("start", action="upload_gcs", source=local_path, destination=gcs_path)
+
+    cmd = build_rsync_command(
+        local_path, gcs_path, dry_run=dry_run, delete_extras=delete_extras
+    )
     try:
         subprocess.run(cmd, check=True)
         emit_status('complete', action='upload_gcs')

--- a/initial/configs/upload/upload_trail_cam_v2.json
+++ b/initial/configs/upload/upload_trail_cam_v2.json
@@ -1,4 +1,6 @@
 {
   "local_path": "/home/excessus/ai_projects/yolov8/transfers/GCS_upload/trail_cam_v2/images",
-  "gcs_path": "gs://excessus-home-labelstudio/datasets1"
+  "gcs_path": "gs://excessus-home-labelstudio/datasets1",
+  "dry_run": false,
+  "delete_extras": false
 }

--- a/initial/configs/upload/upload_trail_cam_v2_mistake_fix.json
+++ b/initial/configs/upload/upload_trail_cam_v2_mistake_fix.json
@@ -1,4 +1,6 @@
 {
   "local_path": "/home/excessus/ai_projects/yolov8/trail_cam_raw",
-  "gcs_path": "gs://excessus-home-labelstudio/datasets1"
+  "gcs_path": "gs://excessus-home-labelstudio/datasets1",
+  "dry_run": false,
+  "delete_extras": false
 }


### PR DESCRIPTION
## Summary
- Allow callers to control `gsutil rsync` via new `dry_run` and `delete_extras` options
- Pull these options from config or environment variables and remove old constants
- Extend sample upload configs with the new flags

## Testing
- `python -m py_compile backend/upload_gcs.py initial/scripts/upload_gcs.py`
- `python -m json.tool initial/configs/upload/upload_trail_cam_v2.json`
- `python -m json.tool initial/configs/upload/upload_trail_cam_v2_mistake_fix.json`


------
https://chatgpt.com/codex/tasks/task_e_688f511e8f2c8331978e3cdacfce05f2