### PR TITLE
feat: add configurable prediction batch size

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,3 +23,14 @@ The backend loads this file automatically using [`python-dotenv`](https://pypi.o
 When these variables are not provided, the application will fall back to the defaults above which are relative to the repository root.
 
 
+## Prediction Configuration
+
+Prediction jobs are driven by JSON configuration files. In addition to the existing keys (`mode`, `model`, `source`, `output`, and optional `conf`), the backend now supports a `batch` key:
+
+| Key     | Description                                                                 |
+|---------|-----------------------------------------------------------------------------|
+| `batch` | Number of images or video frames to process at once. Set `1` for per-image inference or increase to enable batched video processing. |
+
+Including `"batch": 1` in a config file enforces per-image inference. Larger values process multiple frames simultaneously during prediction.
+
+

--- a/backend/yolo.py
+++ b/backend/yolo.py
@@ -6,7 +6,7 @@ from ultralytics import YOLO
 from .utils import emit_status, set_status_callback
 
 
-def run_prediction(cfg, db=None):
+def run_prediction(cfg, db=None, batch: int = 1):
     model_path = cfg['model']
     source = cfg['source']
     output = cfg['output']
@@ -54,6 +54,7 @@ def run_prediction(cfg, db=None):
         name=name,
         device=0,
         stream=True,
+        batch=batch,
     )
 
     for r in results:
@@ -123,7 +124,7 @@ def run(config_path: str, mode_override: str | None = None, db=None) -> None:
         cfg["mode"] = mode_override
     mode = cfg.get("mode")
     if mode == "predict":
-        run_prediction(cfg, db=db)
+        run_prediction(cfg, db=db, batch=cfg.get('batch', 1))
     elif mode == "train":
         run_training(cfg, db=db)
     else:

--- a/initial/configs/predict/predict_blink_v1.json
+++ b/initial/configs/predict/predict_blink_v1.json
@@ -5,6 +5,7 @@
   "output": "/home/excessus/ai_projects/yolov8/outputs/predictions/blink_v1/",
   "conf": 0.25,
   "save": true,
-  "save_txt": true
+  "save_txt": true,
+  "batch": 1
 }
 

--- a/initial/configs/predict/predict_sample.json
+++ b/initial/configs/predict/predict_sample.json
@@ -3,6 +3,7 @@
   "model": "/home/excessus/ai_projects/yolov8/models/trail_cam_v1_best.pt",
   "source": "/home/excessus/ai_projects/yolov8/trail_cam_raw/",
   "output": "/home/excessus/ai_projects/yolov8/outputs/predictions/trail_cam_v2/",
-  "conf": 0.25
+  "conf": 0.25,
+  "batch": 1
 }
 

--- a/initial/configs/predict/predict_trail_cam.json
+++ b/initial/configs/predict/predict_trail_cam.json
@@ -5,6 +5,7 @@
   "output": "/home/excessus/ai_projects/yolov8/outputs/predictions/trail_cam_v3/",
   "conf": 0.25,
   "save": true,
-  "save_txt": true
+  "save_txt": true,
+  "batch": 1
 }
 


### PR DESCRIPTION
## Summary
- allow prediction runs to accept a configurable `batch` size
- document new `batch` config option for prediction jobs
- update sample prediction configs with `batch` key

## Testing
- `pytest`
- `python -m py_compile backend/yolo.py`


------
https://chatgpt.com/codex/tasks/task_e_688f55c18f888331aceda35dc80a58e7