### PR TITLE
chore: remove unused subprocess import

### DIFF
--- a/backend/yolo.py
+++ b/backend/yolo.py
@@ -1,7 +1,6 @@
 import os
 import sys
 import json
-import subprocess
 from ultralytics import YOLO
 from .utils import emit_status, set_status_callback
 


### PR DESCRIPTION
## Summary
- remove unused subprocess import from YOLO backend module

## Testing
- `ruff check backend/yolo.py`


------
https://chatgpt.com/codex/tasks/task_e_688f5760ff9c83319f7f52e45eed63ec