### PR TITLE
Pin better-sqlite3 and externalize in Next.js server build

### DIFF
--- a/site/next.config.mjs
+++ b/site/next.config.mjs
@@ -9,6 +9,10 @@ const nextConfig = {
   images: {
     unoptimized: true,
   },
+  webpack: (config, { isServer }) => {
+    if (isServer) config.externals.push("better-sqlite3")
+    return config
+  },
 }
 
 export default nextConfig

--- a/site/package.json
+++ b/site/package.json
@@ -39,7 +39,7 @@
     "@radix-ui/react-tooltip": "1.1.6",
     "@tailwindcss/oxide": "^4.1.11",
     "autoprefixer": "^10.4.20",
-    "better-sqlite3": "latest",
+    "better-sqlite3": "^12.2.0",
     "child_process": "latest",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",

--- a/site/pnpm-lock.yaml
+++ b/site/pnpm-lock.yaml
@@ -99,7 +99,7 @@ importers:
         specifier: ^10.4.20
         version: 10.4.21(postcss@8.5.6)
       better-sqlite3:
-        specifier: latest
+        specifier: ^12.2.0
         version: 12.2.0
       child_process:
         specifier: latest


### PR DESCRIPTION
## Summary
- pin `better-sqlite3` to `^12.2.0`
- externalize `better-sqlite3` from server webpack build

## Testing
- `pnpm install`
- `pnpm rebuild better-sqlite3`
- `pnpm build`
- `pnpm lint` *(fails: How would you like to configure ESLint?)*

------
https://chatgpt.com/codex/tasks/task_e_688f693312b88331852df2da94fd79ea