### PR TITLE
chore: move sample data to dev-only seed script

### DIFF
--- a/site/scripts/init_database.sql
+++ b/site/scripts/init_database.sql
@@ -147,12 +147,5 @@ CREATE INDEX IF NOT EXISTS idx_system_metrics_type ON system_metrics(metric_type
 CREATE INDEX IF NOT EXISTS idx_system_metrics_timestamp ON system_metrics(timestamp);
 CREATE INDEX IF NOT EXISTS idx_file_operations_status ON file_operations(status);
 
--- Insert default data
-INSERT OR IGNORE INTO datasets (name, path, type, description) VALUES 
-('Sample Construction', '/data/construction_sample', 'yolo', 'Sample construction equipment dataset'),
-('Vehicle Detection', '/data/vehicles', 'yolo', 'Vehicle detection dataset'),
-('Safety Equipment', '/data/safety', 'yolo', 'Safety equipment detection dataset');
-
--- Insert sample activity log
-INSERT INTO activity_logs (action, details, status) VALUES 
-('Database initialized', '{"tables_created": 8, "indexes_created": 10}', 'success');
+-- Sample dataset and activity log inserts have been moved to 'site/scripts/seed_sample_data.sql'
+-- for optional development/demo seeding.

--- a/site/scripts/seed_sample_data.sql
+++ b/site/scripts/seed_sample_data.sql
@@ -1,0 +1,10 @@
+-- Seed sample datasets and activity log for development or demo environments.
+-- Execute after running init_database.sql if sample data is desired.
+
+INSERT OR IGNORE INTO datasets (name, path, type, description) VALUES
+('Sample Construction', '/data/construction_sample', 'yolo', 'Sample construction equipment dataset'),
+('Vehicle Detection', '/data/vehicles', 'yolo', 'Vehicle detection dataset'),
+('Safety Equipment', '/data/safety', 'yolo', 'Safety equipment detection dataset');
+
+INSERT INTO activity_logs (action, details, status) VALUES
+('Database initialized', '{"tables_created": 8, "indexes_created": 10}', 'success');


### PR DESCRIPTION
## Summary
- remove demo dataset and activity log inserts from init_database.sql
- add seed_sample_data.sql for optional development seeding

## Testing
- `pnpm lint` *(fails: requires interactive ESLint setup)*
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_688f6bbb22c48331b3b34155853913c2