### PR TITLE
feat: add placeholder pages

### DIFF
--- a/site/app/data/annotate/page.tsx
+++ b/site/app/data/annotate/page.tsx
@@ -1,0 +1,10 @@
+export default function AnnotateDataPage() {
+  return (
+    <div className="min-h-screen bg-gradient-to-br from-slate-50 to-slate-100">
+      <div className="container mx-auto px-4 py-8">
+        <h1 className="text-3xl font-bold">Annotate Data</h1>
+        <p className="text-muted-foreground">Coming soon.</p>
+      </div>
+    </div>
+  )
+}

--- a/site/app/data/organize/page.tsx
+++ b/site/app/data/organize/page.tsx
@@ -1,0 +1,10 @@
+export default function OrganizeDataPage() {
+  return (
+    <div className="min-h-screen bg-gradient-to-br from-slate-50 to-slate-100">
+      <div className="container mx-auto px-4 py-8">
+        <h1 className="text-3xl font-bold">Organize Data</h1>
+        <p className="text-muted-foreground">Coming soon.</p>
+      </div>
+    </div>
+  )
+}

--- a/site/app/models/page.tsx
+++ b/site/app/models/page.tsx
@@ -1,0 +1,10 @@
+export default function ModelsPage() {
+  return (
+    <div className="min-h-screen bg-gradient-to-br from-slate-50 to-slate-100">
+      <div className="container mx-auto px-4 py-8">
+        <h1 className="text-3xl font-bold">Models</h1>
+        <p className="text-muted-foreground">Coming soon.</p>
+      </div>
+    </div>
+  )
+}

--- a/site/app/predict/batch/page.tsx
+++ b/site/app/predict/batch/page.tsx
@@ -1,0 +1,10 @@
+export default function BatchPredictionPage() {
+  return (
+    <div className="min-h-screen bg-gradient-to-br from-slate-50 to-slate-100">
+      <div className="container mx-auto px-4 py-8">
+        <h1 className="text-3xl font-bold">Batch Prediction</h1>
+        <p className="text-muted-foreground">Coming soon.</p>
+      </div>
+    </div>
+  )
+}

--- a/site/app/predict/video/page.tsx
+++ b/site/app/predict/video/page.tsx
@@ -1,0 +1,10 @@
+export default function VideoPredictionPage() {
+  return (
+    <div className="min-h-screen bg-gradient-to-br from-slate-50 to-slate-100">
+      <div className="container mx-auto px-4 py-8">
+        <h1 className="text-3xl font-bold">Video Prediction</h1>
+        <p className="text-muted-foreground">Coming soon.</p>
+      </div>
+    </div>
+  )
+}

--- a/site/app/training/history/page.tsx
+++ b/site/app/training/history/page.tsx
@@ -1,0 +1,10 @@
+export default function TrainingHistoryPage() {
+  return (
+    <div className="min-h-screen bg-gradient-to-br from-slate-50 to-slate-100">
+      <div className="container mx-auto px-4 py-8">
+        <h1 className="text-3xl font-bold">Training History</h1>
+        <p className="text-muted-foreground">Coming soon.</p>
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- add basic placeholder page for upcoming data organization feature
- add placeholder views for data annotation, model management, training history, and new prediction modes

## Testing
- `pnpm lint` *(fails: How would you like to configure ESLint?)*

------
https://chatgpt.com/codex/tasks/task_e_688f9335a5008331bfcbffcdf6e3c363