### PR TITLE
feat: centralize data directory paths

### DIFF
--- a/site/app/api/scripts/route.ts
+++ b/site/app/api/scripts/route.ts
@@ -4,6 +4,7 @@ import path from "path"
 import fs from "fs/promises"
 import { WorkflowDatabase } from "@/lib/database"
 import { allowedScripts } from "@/config/scripts"
+import { DATA_DIR } from "@/lib/paths"
 
 export async function POST(request: NextRequest) {
   try {
@@ -17,8 +18,7 @@ export async function POST(request: NextRequest) {
     // Create temporary config file if config is provided
     let configPath: string | null = null
     if (config) {
-      const dataDir = process.env.DATA_DIR || path.join(process.cwd(), "..", "data")
-      const configDir = path.join(dataDir, "temp", "configs")
+      const configDir = path.join(DATA_DIR, "temp", "configs")
       await fs.mkdir(configDir, { recursive: true })
       configPath = path.join(configDir, `config_${Date.now()}.json`)
       await fs.writeFile(configPath, JSON.stringify(config, null, 2))

--- a/site/app/api/status/route.ts
+++ b/site/app/api/status/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from "next/server"
 import { spawn } from "child_process"
 import path from "path"
 import fs from "fs/promises"
+import { DATA_DIR } from "@/lib/paths"
 //import { WorkflowDatabase } from "@/lib/database"
 
 async function getActiveProcesses() {
@@ -80,8 +81,7 @@ async function getGPUStatus() {
 
 async function getStorageStatus() {
   try {
-    const dataDir = process.env.DATA_DIR || path.join(process.cwd(), "..", "data")
-    const stats = await fs.stat(dataDir)
+    const stats = await fs.stat(DATA_DIR)
     return {
       available: true,
       // Add more storage metrics as needed
@@ -93,8 +93,7 @@ async function getStorageStatus() {
 
 async function getRecentLogs() {
   try {
-    const dataDir = process.env.DATA_DIR || path.join(process.cwd(), "..", "data")
-    const logsDir = path.join(dataDir, "logs", "api")
+    const logsDir = path.join(DATA_DIR, "logs", "api")
     const files = await fs.readdir(logsDir)
     const recentFile = files.sort().pop()
 

--- a/site/lib/database.ts
+++ b/site/lib/database.ts
@@ -1,12 +1,14 @@
+import fs from "fs"
 import path from "path"
+import { DATA_DIR } from "@/lib/paths"
 
 let db: ReturnType<typeof import("better-sqlite3")> | null = null
 
 function getDB() {
   if (!db) {
     const Database = require("better-sqlite3") as typeof import("better-sqlite3")
-    const dataDir = process.env.DATA_DIR || path.join(process.cwd(), "data")
-    const dbPath = process.env.DB_PATH || path.join(dataDir, "workflow.db")
+    fs.mkdirSync(DATA_DIR, { recursive: true })
+    const dbPath = process.env.DB_PATH ?? path.join(DATA_DIR, "workflow.db")
     db = new Database(dbPath)
 
     // Initialize schema

--- a/site/lib/paths.ts
+++ b/site/lib/paths.ts
@@ -1,0 +1,3 @@
+import path from "path"
+
+export const DATA_DIR = process.env.DATA_DIR ?? path.join(process.cwd(), "..", "data")


### PR DESCRIPTION
## Summary
- add shared DATA_DIR helper with default to ../data
- ensure database folder exists before creating workflow.db
- reuse DATA_DIR in status and scripts API routes

## Testing
- `pnpm lint` *(fails: asks for ESLint configuration)*


------
https://chatgpt.com/codex/tasks/task_e_688f95785c7c8331b11e03e0255f02e8