### PR TITLE
feat(api): add training and project endpoints

### DIFF
--- a/site/app/api/projects/route.ts
+++ b/site/app/api/projects/route.ts
@@ -1,6 +1,13 @@
 import { NextResponse } from "next/server"
 import { WorkflowDatabase } from "@/lib/database"
 
+interface ProjectPayload {
+  name: string
+  type: string
+  status?: string
+  config?: string
+}
+
 export async function GET() {
   try {
     const projects = WorkflowDatabase.getProjects()
@@ -8,5 +15,29 @@ export async function GET() {
   } catch (error) {
     console.error("Failed to fetch projects:", error)
     return NextResponse.json({ error: "Failed to fetch projects" }, { status: 500 })
+  }
+}
+
+export async function POST(request: Request) {
+  try {
+    const body = (await request.json()) as ProjectPayload
+
+    if (!body?.name || !body?.type) {
+      return NextResponse.json(
+        { error: "Missing required fields" },
+        { status: 400 },
+      )
+    }
+
+    const id = WorkflowDatabase.createProject(body)
+    const project = WorkflowDatabase.getProject(id)
+
+    return NextResponse.json(project, { status: 201 })
+  } catch (error) {
+    console.error("Failed to create project:", error)
+    return NextResponse.json(
+      { error: "Failed to create project" },
+      { status: 500 },
+    )
   }
 }

--- a/site/app/api/training/route.ts
+++ b/site/app/api/training/route.ts
@@ -1,0 +1,16 @@
+import { NextResponse } from "next/server"
+import { WorkflowDatabase } from "@/lib/database"
+
+export async function GET() {
+  try {
+    const sessions = WorkflowDatabase.getTrainingSessions()
+    return NextResponse.json(sessions)
+  } catch (error) {
+    console.error("Failed to fetch training sessions:", error)
+    return NextResponse.json(
+      { error: "Failed to fetch training sessions" },
+      { status: 500 },
+    )
+  }
+}
+


### PR DESCRIPTION
## Summary
- support project creation via POST `/api/projects` and validate required fields
- add GET `/api/training` to list training sessions
- API endpoints use `WorkflowDatabase` and return JSON with error handling

## Testing
- `pnpm lint` *(fails: prompts to configure ESLint)*

------
https://chatgpt.com/codex/tasks/task_e_688fa236761883318ec792776058ef45